### PR TITLE
Fix Manifest.json to include version as required in home assistant version 2021.6

### DIFF
--- a/custom_components/growatt/manifest.json
+++ b/custom_components/growatt/manifest.json
@@ -3,6 +3,7 @@
   "name": "Growatt solar panels",
   "documentation": "https://github.com/timvancann/homeassistant-growatt",
   "requirements": ["growatt==0.0.2"],
+  "version": "0.0.3.1
   "dependencies": [],
   "codeowners": ["@timvancann"]
 }

--- a/custom_components/growatt/manifest.json
+++ b/custom_components/growatt/manifest.json
@@ -3,7 +3,7 @@
   "name": "Growatt solar panels",
   "documentation": "https://github.com/timvancann/homeassistant-growatt",
   "requirements": ["growatt==0.0.2"],
-  "version": "0.0.3.1
+  "version": "0.0.3.1",
   "dependencies": [],
   "codeowners": ["@timvancann"]
 }


### PR DESCRIPTION
I added the version in the manifest.json to make sure that its compatible with home assistant version 2021.6